### PR TITLE
add 'Order' optional argument to time-series data request definition

### DIFF
--- a/spec/definitions/TimeSeriesDataReq.yaml
+++ b/spec/definitions/TimeSeriesDataReq.yaml
@@ -42,6 +42,10 @@ properties:
               type: string
               description: the timestamp of the end of the time range to request data from
               example: "20170401000000"
+            Order:
+              type: string
+              description: the order by which data samples are returned. By default samples are returned in a descending order. To order them in an ascending order this option must be set to "asc"
+              example: "asc"
             StructureType:
               type: string
               description: the type of response. It should default to TimeSeries

--- a/spec/paths/timeSeries@get.yaml
+++ b/spec/paths/timeSeries@get.yaml
@@ -1,6 +1,6 @@
 post:
   summary: Get sensor data
-  description: This action returns data from sensor(s) specified in the request body. Requests must define a time range by specifying beginning and end UTC timestamp in the yyyymmddHHMMSS format. Currently time ranges are limited to a maximum of 10 days per request.
+  description: This action returns data from sensor(s) specified in the request body. Requests must define a time range by specifying beginning and end UTC timestamp in the yyyymmddHHMMSS format. Currently time ranges are limited to a maximum of 10 days per request. Data samples are returned in descending order (from the most recent to the oldest one) unless otherwise specified.
   tags:
     - Measurements
   consumes:


### PR DESCRIPTION
This PR updates the Thingful GROW Node documentation by describing the optional "Order" flag that can be set when requesting time series data. Setting this option to "asc" (or "ASC") will revert the default order and return data samples from the oldest to the newest.

This feature is not live yet and will be deployed to production once this PR has been accepted.  