### PR TITLE
Missing gulp package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,37 @@
+# Makefile for Thingful Grow Node documentation
+#
+# Author: m4rco
+
+HOST_DOCS_PORT = 3000
+DOCKER_DOCS_PORT = 3000
+HOST_SWAGGER_PORT = 5000
+DOCKER_SWAGGER_PORT = 5000
+
+# override default documentation port if set
+ifdef docs_port
+	HOST_DOCS_PORT = $(docs_port)
+endif
+
+# override default swagger_port port if set
+ifdef swagger_port
+	HOST_SWAGGER_PORT = $(swagger_port)
+endif
+
 .PHONY: docker-build
 docker-build: ## build the docker image, installs the required packages and tags the image.
 	docker build -t thingful/grow-docs .
 
-.PHONY: docker-dev 
+.PHONY: docker-dev
 docker-dev: ## run the docker container and mounts the app directory on the container.
-	docker run --name thingful-grow-docs -v `pwd`:/src/app -p 3000:3000 -p 5000:5000 -d thingful/grow-docs
+	docker run --name thingful-grow-docs \
+		-v `pwd`:/src/app -p $(HOST_DOCS_PORT):$(DOCKER_DOCS_PORT) \
+		-p $(HOST_SWAGGER_PORT):$(DOCKER_SWAGGER_PORT) \
+		-d thingful/grow-docs
 
 .PHONY: docker-rm
 docker-rm: ## removes the 'thingful-grow-docs' docker container.
 	docker rm thingful-grow-docs
 
-.PHONY: help 
+.PHONY: help
 help:
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,14 @@
         "negotiator": "0.5.3"
       }
     },
+    "ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-gray": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
@@ -88,6 +96,23 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
+    },
+    "array-sort": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+      "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+      "requires": {
+        "default-compare": "1.0.0",
+        "get-value": "2.0.6",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -456,6 +481,50 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.4",
+        "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+          "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
     "connect": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.5.tgz",
@@ -537,6 +606,15 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "copy-props": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.1.tgz",
+      "integrity": "sha1-Zl/DIEbKhKiYq6o8WUXn8kjMugA=",
+      "requires": {
+        "each-props": "1.3.1",
+        "is-plain-object": "2.0.4"
+      }
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -577,6 +655,14 @@
         "http-errors": "1.3.1"
       }
     },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "requires": {
+        "es5-ext": "0.10.39"
+      }
+    },
     "dateformat": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
@@ -604,6 +690,21 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+    },
+    "default-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+      "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
+      "requires": {
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
     },
     "defaults": {
       "version": "1.0.3",
@@ -680,6 +781,15 @@
         "readable-stream": "1.1.14"
       }
     },
+    "each-props": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.1.tgz",
+      "integrity": "sha1-/BOPUeOid0KG1IWOAtbn3kYt4Vg=",
+      "requires": {
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0"
+      }
+    },
     "ebnf-parser": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/ebnf-parser/-/ebnf-parser-0.1.10.tgz",
@@ -734,6 +844,34 @@
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
           "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
         }
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.39",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
+      "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.39",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.39"
       }
     },
     "escape-html": {
@@ -1480,6 +1618,69 @@
         }
       }
     },
+    "gulp-cli": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.0.1.tgz",
+      "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
+      "requires": {
+        "ansi-colors": "1.1.0",
+        "archy": "1.0.0",
+        "array-sort": "1.0.0",
+        "color-support": "1.1.3",
+        "concat-stream": "1.6.0",
+        "copy-props": "2.0.1",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "interpret": "1.1.0",
+        "isobject": "3.0.1",
+        "liftoff": "2.5.0",
+        "matchdep": "2.0.0",
+        "mute-stdout": "1.0.0",
+        "pretty-hrtime": "1.0.3",
+        "replace-homedir": "1.0.0",
+        "semver-greatest-satisfied-range": "1.1.0",
+        "v8flags": "3.0.2",
+        "yargs": "7.1.0"
+      },
+      "dependencies": {
+        "v8flags": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.2.tgz",
+          "integrity": "sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==",
+          "requires": {
+            "homedir-polyfill": "1.0.1"
+          }
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "requires": {
+            "camelcase": "3.0.0"
+          }
+        }
+      }
+    },
     "gulp-connect": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/gulp-connect/-/gulp-connect-4.2.0.tgz",
@@ -2192,6 +2393,17 @@
         "object-visit": "1.0.1"
       }
     },
+    "matchdep": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+      "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+      "requires": {
+        "findup-sync": "2.0.0",
+        "micromatch": "3.1.5",
+        "resolve": "1.5.0",
+        "stack-trace": "0.0.10"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -2351,6 +2563,11 @@
       "requires": {
         "duplexer2": "0.0.2"
       }
+    },
+    "mute-stdout": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.0.tgz",
+      "integrity": "sha1-WzLqB+tDyd7WEwQ0z5JvRrKn/U0="
     },
     "nanomatch": {
       "version": "1.2.7",
@@ -2825,6 +3042,11 @@
         "extend-shallow": "2.0.1"
       }
     },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2839,6 +3061,16 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+    },
+    "replace-homedir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+      "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+      "requires": {
+        "homedir-polyfill": "1.0.1",
+        "is-absolute": "1.0.0",
+        "remove-trailing-separator": "1.1.0"
+      }
     },
     "require-dir": {
       "version": "0.3.2",
@@ -2912,6 +3144,14 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+    },
+    "semver-greatest-satisfied-range": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+      "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+      "requires": {
+        "sver-compat": "1.5.0"
+      }
     },
     "send": {
       "version": "0.13.2",
@@ -3275,6 +3515,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "static-eval": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.3.tgz",
@@ -3477,6 +3722,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "sver-compat": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+      "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
     },
     "swagger-editor": {
       "version": "2.10.5",
@@ -3885,6 +4139,11 @@
         "media-typer": "0.3.0",
         "mime-types": "2.1.17"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uid-safe": {
       "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "cors": "^2.7.1",
     "deploy-to-gh-pages": "^1.1.0",
     "gulp": "^3.9.1",
+    "gulp-cli": "2.0.1",
     "gulp-connect": "^4.2.0",
     "gulp-util": "^3.0.7",
     "portfinder": "^1.0.3",


### PR DESCRIPTION
This PR adds the missing `gulp-cli` package that was preventing the app from being served via npm `scripts`.

It also updates the Makefile to accept ports arguments when running the docker container.